### PR TITLE
Use fine-grained feature detection instead of `rustc_version`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["rust-patterns"]
 repository = "https://github.com/sunfishcode/char-device"
 exclude = ["/.github"]
 
-[build-dependencies]
-rustc_version = "0.4.0"
-
 [dependencies]
 async-std = { version = "1.10.0", optional = true }
 tokio = { version = "1.8.1", optional = true, features = ["fs"] }

--- a/build.rs
+++ b/build.rs
@@ -1,29 +1,41 @@
+use std::env::var;
+use std::io::Write;
+
 fn main() {
-    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
-        .expect("query rustc release channel")
-        .channel
-    {
-        for feature in &[
-            "can_vector",         // https://github.com/rust-lang/rust/issues/69941
-            "clamp",              // https://github.com/rust-lang/rust/issues/44095
-            "extend_one",         // https://github.com/rust-lang/rust/issues/72631
-            "pattern",            // https://github.com/rust-lang/rust/issues/27721
-            "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
-            "shrink_to",          // https://github.com/rust-lang/rust/issues/56431
-            "toowned_clone_into", // https://github.com/rust-lang/rust/issues/41263
-            "try_reserve",        // https://github.com/rust-lang/rust/issues/56431
-            "unix_socket_peek",   // https://github.com/rust-lang/rust/issues/76923
-            "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
-            "with_options",       // https://github.com/rust-lang/rust/issues/65439
-            "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
-            // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
-            "windows_file_type_ext",
-        ] {
-            println!("cargo:rustc-cfg={}", feature);
-        }
-    }
+    use_feature_or_nothing("can_vector"); // https://github.com/rust-lang/rust/issues/69941
+    use_feature_or_nothing("write_all_vectored"); // https://github.com/rust-lang/rust/issues/70436
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    let out_dir = var("OUT_DIR").unwrap();
+    let rustc = var("RUSTC").unwrap();
+
+    let mut child = std::process::Command::new(rustc)
+        .arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--out-dir")
+        .arg(out_dir) // Put the output somewhere inconsequential.
+        .arg("-") // Read from stdin.
+        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+
+    child.wait().unwrap().success()
 }


### PR DESCRIPTION
Test whether rustc supports specific features, rather than assuming that
Nightly has all the features and Stable doesn't.