### PR TITLE
Bring back tokio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,4 @@
 This crate defines the [`CharDevice`] struct, a simple wrapper around
 `std::fs::File` for character devices.
 
-Support for async-std and tokio is temporarily disabled until those crates
-contain the needed implementations of the I/O safety traits.
-
 [`CharDevice`]: https://docs.rs/char-device/latest/char_device/struct.CharDevice.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,22 +4,14 @@
 #![cfg_attr(can_vector, feature(can_vector))]
 #![cfg_attr(write_all_vectored, feature(write_all_vectored))]
 
-/*
 #[cfg(feature = "async-std")]
 mod async_std;
-*/
 mod char_device;
-/*
 #[cfg(feature = "tokio")]
 mod tokio;
-*/
 
-/*
 #[cfg(feature = "async-std")]
 pub use crate::async_std::AsyncStdCharDevice;
-*/
 pub use crate::char_device::CharDevice;
-/*
 #[cfg(feature = "tokio")]
 pub use crate::tokio::TokioCharDevice;
-*/

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -40,7 +40,7 @@ impl TokioCharDevice {
     pub async fn new<Filelike: IntoFilelike + AsyncRead + AsyncWrite>(
         filelike: Filelike,
     ) -> io::Result<Self> {
-        Self::_new(File::from_std(filelike)).await
+        Self::_new(File::from_into_filelike(filelike)).await
     }
 
     async fn _new(file: File) -> io::Result<Self> {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -40,7 +40,7 @@ impl TokioCharDevice {
     pub async fn new<Filelike: IntoFilelike + AsyncRead + AsyncWrite>(
         filelike: Filelike,
     ) -> io::Result<Self> {
-        Self::_new(File::from_into_filelike(filelike)).await
+        Self::_new(File::from_std(filelike)).await
     }
 
     async fn _new(file: File) -> io::Result<Self> {
@@ -57,7 +57,8 @@ impl TokioCharDevice {
 
         #[cfg(windows)]
         {
-            let file_type = winx::winapi_util::file::typ(&*file.as_filelike_view::<std::fs::File>())?;
+            let file_type =
+                winx::winapi_util::file::typ(&*file.as_filelike_view::<std::fs::File>())?;
             if !file_type.is_char() {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -9,7 +9,7 @@ use tokio::io::{self, AsyncRead, AsyncWrite, ReadBuf};
 #[cfg(not(windows))]
 use {
     io_extras::os::rustix::{AsRawFd, AsRawReadWriteFd, AsReadWriteFd, RawFd},
-    io_lifetimes::AsFd, // io_lifetimes::{AsFd, BorrowedFd},
+    io_lifetimes::AsFd,
     rustix::fs::FileTypeExt,
 };
 #[cfg(windows)]

--- a/tests/null.rs
+++ b/tests/null.rs
@@ -1,12 +1,8 @@
-/*
 #[cfg(feature = "async-std")]
 use char_device::AsyncStdCharDevice;
-*/
 use char_device::CharDevice;
-/*
 #[cfg(feature = "tokio")]
 use char_device::TokioCharDevice;
-*/
 
 #[test]
 fn null() {
@@ -19,7 +15,6 @@ fn null() {
     assert_eq!(char_device.read(&mut buf).unwrap(), 0);
 }
 
-/*
 #[cfg(feature = "async-std")]
 #[async_std::test]
 async fn async_std_null() {
@@ -43,4 +38,3 @@ async fn tokio_null() {
     let mut buf = vec![0_u8; 32];
     assert_eq!(char_device.read(&mut buf).await.unwrap(), 0);
 }
-*/

--- a/tests/tty.rs
+++ b/tests/tty.rs
@@ -1,14 +1,10 @@
 #![cfg(unix)]
 
-/*
 #[cfg(feature = "async-std")]
 use char_device::AsyncStdCharDevice;
-*/
 use char_device::CharDevice;
-/*
 #[cfg(feature = "tokio")]
 use char_device::TokioCharDevice;
-*/
 
 #[test]
 fn tty() {
@@ -25,7 +21,6 @@ fn tty() {
     };
 }
 
-/*
 #[cfg(feature = "async-std")]
 #[async_std::test]
 async fn async_std_tty() {
@@ -57,4 +52,3 @@ async fn tokio_tty() {
         },
     };
 }
-*/


### PR DESCRIPTION
Tokio now supports IO safety traits: https://github.com/tokio-rs/mio/pull/1745

I reverted the PR that disabled support for Tokio.  This PR probably needs more clean up, but it is compiling for me.